### PR TITLE
fix(calculate-suv):Fix an array compare by also handling strings

### DIFF
--- a/src/calculateSUVScalingFactors.ts
+++ b/src/calculateSUVScalingFactors.ts
@@ -70,14 +70,24 @@ function calculateDecayCorrection(instances: InstanceMetadata[]): number[] {
   });
 }
 
-function arrayEquals(a: any[], b: any[]): boolean {
+/**
+ *
+ * @param a Simple value or array of simple values
+ * @param b Simple value or array of simple values
+ * @returns boolean true if the values are equal.
+ */
+const deepEquals = (
+  a: string | number | any[],
+  b: string | number | any[]
+): boolean => {
   return (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === b.length &&
-    a.every((val, index) => val === b[index])
+    a === b ||
+    (Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((val, index) => val === b[index]))
   );
-}
+};
 
 /**
  * Calculate the SUV factor
@@ -113,8 +123,7 @@ export default function calculateSUVScalingFactors(
   const isSingleSeries = instances.every(instance => {
     return (
       instance.Units === Units &&
-      (instance.CorrectedImage === CorrectedImage ||
-        arrayEquals(instance.CorrectedImage, CorrectedImage)) &&
+      deepEquals(instance.CorrectedImage, CorrectedImage) &&
       instance.PatientWeight === PatientWeight &&
       instance.PatientSex === PatientSex &&
       instance.PatientSize === PatientSize &&

--- a/src/calculateSUVScalingFactors.ts
+++ b/src/calculateSUVScalingFactors.ts
@@ -113,7 +113,8 @@ export default function calculateSUVScalingFactors(
   const isSingleSeries = instances.every(instance => {
     return (
       instance.Units === Units &&
-      arrayEquals(instance.CorrectedImage, CorrectedImage) &&
+      (instance.CorrectedImage === CorrectedImage ||
+        arrayEquals(instance.CorrectedImage, CorrectedImage)) &&
       instance.PatientWeight === PatientWeight &&
       instance.PatientSex === PatientSex &&
       instance.PatientSize === PatientSize &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface PhilipsPETPrivateGroup {
  * @interface InstanceMetadata
  */
 export interface InstanceMetadata {
-  CorrectedImage: string[];
+  CorrectedImage: string[] | string; // The dcmjs naturalize produces a string value for single item arrays :-(
   Units: string; // 'BQML' | 'CNTS' | 'GML'; // Units (0x0054,0x1001)
   RadionuclideHalfLife: number; // 	RadionuclideHalfLife(0x0018,0x1075)	in	Radiopharmaceutical	Information	Sequence(0x0054,0x0016)
   RadionuclideTotalDose: number;


### PR DESCRIPTION
The array compare works mostly, except when the value is a string
it fails to compare correctly.