### PR TITLE
fix(calculate-suv): A zero PatientWeight should be considered as if it is missing

### DIFF
--- a/src/calculateSUVScalingFactors.ts
+++ b/src/calculateSUVScalingFactors.ts
@@ -147,7 +147,8 @@ export default function calculateSUVScalingFactors(
     );
   }
 
-  if (PatientWeight === null || PatientWeight === undefined) {
+  // Treat null, undefined and zero as a missing PatientWeight.
+  if (!PatientWeight) {
     throw new Error(
       'PatientWeight value is missing. It is not possible to calculate the SUV factors'
     );

--- a/test/calculateSUVScalingFactors.test.ts
+++ b/test/calculateSUVScalingFactors.test.ts
@@ -187,6 +187,16 @@ describe('calculateSUVScalingFactor Error Handling', () => {
     }).toThrowError('Decay time cannot be less than zero');
   });
 
+  it('throws an Error if the PatientWeight is zero', () => {
+    input[0].PatientWeight = 0;
+
+    expect(() => {
+      calculateSUVScalingFactors(input);
+    }).toThrowError(
+      `PatientWeight value is missing. It is not possible to calculate the SUV factors`
+    );
+  });
+
   it('throws an Error if series-level metadata are different', () => {
     expect(() => {
       calculateSUVScalingFactors(multiInput);


### PR DESCRIPTION
This issue was discovered in [OHIF issue 3587](https://github.com/OHIF/Viewers/issues/3587)
